### PR TITLE
Replace aeronautics_bundled dependency with sable

### DIFF
--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -34,9 +34,9 @@ config="${mod_id}.mixins.json"
     side="BOTH"
 
 [[dependencies.${mod_id}]]
-modId="aeronautics_bundled"
-type="required"
-versionRange="[1.1.3,)"
-ordering="AFTER"
-side="BOTH"
+    modId="sable"
+    type="required"
+    versionRange="[1.1.1,)"
+    ordering="AFTER"
+    side="BOTH"
 


### PR DESCRIPTION
There is not a dependency in this mod's codebase for aeronautics itself, and so replacing the dependency leaves room for future projects that involve sable to use this.